### PR TITLE
More configurable export file name

### DIFF
--- a/vaadin-excel-exporter/src/main/java/org/vaadin/addons/excelexporter/ExportToExcelUtility.java
+++ b/vaadin-excel-exporter/src/main/java/org/vaadin/addons/excelexporter/ExportToExcelUtility.java
@@ -207,17 +207,9 @@ public class ExportToExcelUtility<BEANTYPE> extends ExportUtility {
         else {
             this.resultantSelectedExtension = "xlsx";
         }
-        Calendar calendar = Calendar.getInstance();
         this.resultantExportFileName = ((this.exportExcelConfiguration.getExportFileName() != null && !this.exportExcelConfiguration.getExportFileName()
                                                                                                                                     .isEmpty())
                                                                                                                                             ? this.exportExcelConfiguration.getExportFileName()
-                                                                                                                                                    + "_"
-                                                                                                                                                    + calendar.get(Calendar.YEAR)
-                                                                                                                                                    + "_"
-                                                                                                                                                    + (calendar.get(Calendar.MONTH)
-                                                                                                                                                            + 1)
-                                                                                                                                                    + "_"
-                                                                                                                                                    + calendar.get(Calendar.DATE)
                                                                                                                                             : this.DEFAULT_FILE_NAME)
                 + "." + this.resultantSelectedExtension;
 


### PR DESCRIPTION
Right now, there will be a fix date sufix in the export file name no matter you want it or not and the date format cannot be configured. Just remove it.