### PR TITLE
Vaadin Update 8.2.1

### DIFF
--- a/vaadin-excel-exporter-demo/pom.xml
+++ b/vaadin-excel-exporter-demo/pom.xml
@@ -15,7 +15,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<vaadin.version>8.0.6</vaadin.version>
+		<vaadin.version>8.2.1</vaadin.version>
 		<vaadin.plugin.version>${vaadin.version}</vaadin.plugin.version>
 		<jetty.plugin.version>9.2.3.v20140905</jetty.plugin.version>
 	</properties>

--- a/vaadin-excel-exporter/pom.xml
+++ b/vaadin-excel-exporter/pom.xml
@@ -16,8 +16,8 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<maven.compiler.source>1.8</maven.compiler.source>
 		<maven.compiler.target>1.8</maven.compiler.target>
-		<vaadin.version>8.0.6</vaadin.version>
-		<vaadin.plugin.version>8.0.6</vaadin.plugin.version>
+		<vaadin.version>8.2.1</vaadin.version>
+		<vaadin.plugin.version>8.2.1</vaadin.plugin.version>
 
 		<!-- ZIP Manifest fields -->
 		<Implementation-Version>${project.version}</Implementation-Version>


### PR DESCRIPTION
Vaadin Update in order to fix the problem described from HUANG SCOTT in the comment section of the vaadin directory.

https://vaadin.com/directory/component/excel-exporter
java.lang.NoSuchMethodError: com.vaadin.ui.Grid$Column.getValueProvider() issue

This problem is also described in this issue: https://github.com/bonprix/vaadin-excel-exporter/issues/30